### PR TITLE
singleOrderWorking

### DIFF
--- a/client/components/Admin/Order.js
+++ b/client/components/Admin/Order.js
@@ -1,19 +1,32 @@
 
 import React from 'react';
+import { Route, Link } from 'react-router-dom'
+//import SingleOrder from './SingleOrder';
 
 
 export default function Order(props) {
   console.log(props.orders)
   return (
     <div>
+    <div>
       {props.orders && props.orders.map(order => makeRow(order))}
+    </div>
+    <div>
+        <Route exact path="/myaccount/adminsettings/order/:id" />
+    </div>
     </div>
   );
 }
 
 const makeRow = (order) =>
   <div key={order.id} className="flexContainer">
-    <p>  OrderId: {order.id}  </p>
-    <p>  Status: {order.status}</p>
-    <p>  Email: {order.email}</p>
+    <Link to={`/myaccount/adminsettings/order/${order.id}`}>
+    <div>  OrderId: {order.id}  </div>
+    <div>  Status: {order.status}</div>
+    <div>  Email: {order.email}</div>
+    </Link>
   </div>
+
+
+//render={() => <SingleOrder orders={props.orders} />} 
+

--- a/client/components/Admin/SingleOrder.js
+++ b/client/components/Admin/SingleOrder.js
@@ -1,0 +1,32 @@
+// import React from 'react';
+// import { connect } from 'react-redux'
+// import { orderGetter } from '../../store'
+
+// const SingleOrder = (props, ownProps) => {
+//   const { orders } = props;
+
+//   return (
+//         <div>
+    
+//       </div>
+//   )
+// }
+
+
+
+// const mapState = (state, ownProps) => {
+//   console.log(ownProps, state,"-------------")
+//   return {
+//    orders: ownProps.orders.find(aOrder => aOrder.id == +ownProps.match.params.id)
+//   }
+// }
+
+// const mapDispatch = (dispatch, ownProps) => {
+  
+//   //console.log(ownProps, 'ssdsefsdfsd')
+//   return {
+//     orderGetter: () => dispatch(orderGetter(+ownProps.match.params.id))
+//   }
+// }
+
+// export default connect(mapState, mapDispatch)(SingleOrder)

--- a/client/components/User/UserPage-Order.js
+++ b/client/components/User/UserPage-Order.js
@@ -1,1 +1,51 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { Link } from 'react-router-dom';
+import { getUserOrder} from '../../store/order'
+
+ class UserPageOrders extends Component {
+   componentDidMount() {
+     this.props.getUserOrder(this.props.user.id)
+   }
+   componentWillReceiveProps(nextProps) {
+     if (this.props.user.id !== nextProps.user.id) {
+       let id = +nextProps.user.id
+       this.props.getUserOrder(id)
+     }
+   }
+
+
+   render(){
+    return (
+     <div>
+            <h3 > My Order History</h3>
+           
+        {this.props.order.lineItems ? this.props.order.lineItems.map(lineItem => makeRow(lineItem)) : <h4>You not made any purchases .</h4>}
+      </div>
+    )
+  }
+ } 
+const makeRow = (lineItem) =>
+  <div key={lineItem.id} className="flexContainer">
+    <p>  Price per item: {lineItem.getPrice}  </p>
+    <p>  Quantity: {lineItem.quantity}  </p>
+    <p>  Total: {lineItem.getTotal}  </p>
+    <p>  Product Number: {lineItem.productId}</p>
+  </div>
+//getUserOrder
+const mapState = (state) => {
+  return {order: state.order}
+
+}
+const mapDispatch = (dispatch, ownProp) => ({
+    getUserOrder(userId){
+      dispatch(getUserOrder(userId))
+  }
+})
+
+export default connect(mapState, mapDispatch)(UserPageOrders)
+
+// {
+//   this.props.orders &&
+//   this.props.orders.map((order, i) => order.status}
 

--- a/client/components/User/UserPage.js
+++ b/client/components/User/UserPage.js
@@ -3,7 +3,7 @@ import { Route, Switch, Link } from 'react-router-dom';
 import { connect } from 'react-redux'
 import UserPageDetails from './UserPage-Details'
 import UserPageEdit from './UserPage-Edit'
-//import UserPageOrders from './UserPage-Orders'
+import UserPageOrders from './UserPage-Order'
 import AdminPage from '../Admin'
 
 const UserPage = (props) => {
@@ -29,6 +29,7 @@ const UserPage = (props) => {
             <Route exact path="/myaccount/detail" render={() => <UserPageDetails user={user} />} />
             <Route path="/myaccount/edit" render={() => <UserPageEdit user={user} />} />
             <Route path="/myaccount/adminsettings" component={AdminPage} />
+            <Route path="/myaccount/orders" render={() => <UserPageOrders user={user}/>} />
           </Switch>
         </div>
         :

--- a/client/store/order.js
+++ b/client/store/order.js
@@ -4,6 +4,7 @@ const GET_ONE_ORDER = 'GET_ONE_ORDER'
 const DELETE_LINE_ITEM = 'DELETE_LINE_ITEM'
 const CHECK_OUT = 'CHECK_OUT'
 const GET_ACTIVE_ORDER = 'GET_ACTIVE_ORDER'
+const GET_ORDER = 'GET_ORDER'
 
 const getOneOrder = order => ({
   type: GET_ONE_ORDER,
@@ -24,7 +25,11 @@ const getActiveOrder = order => ({
   type: GET_ACTIVE_ORDER,
   order
 })
+const getOrder = (order) => ({
+  type: GET_ORDER,
+  order
 
+})
 /**
  * THUNK CREATORS
  **/
@@ -85,6 +90,16 @@ export const removeLineItem = (lineItemId) => {
   }
 }
 
+export const getUserOrder = (userId) => {
+  return function thunk(dispatch){
+    return axios.get(`/api/users/${userId}/orders`)
+      .then(order =>  order.data)
+      .then(orderData => {
+          dispatch(getOrder(orderData))
+        })
+      }
+  }
+
 export default function (state = {}, action) {
   switch (action.type) {
     case GET_ONE_ORDER:
@@ -94,6 +109,8 @@ export default function (state = {}, action) {
     case CHECK_OUT:
       return action.order
     case GET_ACTIVE_ORDER:
+      return action.order
+    case GET_ORDER:
       return action.order
     default:
       return state

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -33,13 +33,16 @@ router.get('/:id', (req, res, next) => {
 router.get('/:id/orders', (req, res, next) => {
   Order.findAll({
     where: {
-      userId: req.params.id
+      userId: req.params.id,
     },
-    include: { model: LineItem }
+  include: [{
+      model: LineItem}]
   })
-    .then(orders => res.json(orders))
-    .catch(next);
-});
+    .then(instanceArr => instanceArr[0])
+    .then(order => res.json(order))
+    .catch(next)
+})
+
 
 router.get('/:id/addresses', (req, res, next) => {
   Address.findAll({
@@ -69,7 +72,7 @@ router.delete('/:id', (req, res, next) => {
 });
 
 router.get('/:id/cart', (req, res, next) => {
-  if(req.user){
+  if (req.user){
     User.findById(req.params.id)
       .then(user => {
         Order.findOrCreate({
@@ -95,3 +98,4 @@ router.get('/:id/cart', (req, res, next) => {
     return req.session.cart
   }
 })
+


### PR DESCRIPTION
orders for single user is working 
there is a conflict correct one is this:


import React from 'react';
import { Route, Link } from 'react-router-dom'

export default function Order(props) {
  console.log(props.orders)
  return (
    <div>
    <div>
      {props.orders && props.orders.map(order => makeRow(order))}
    </div>
    <div>
        <Route exact path="/myaccount/adminsettings/order/:id" />
    </div>
    </div>
  );
}

const makeRow = (order) =>
  <div key={order.id} className="flexContainer">
    <Link to={`/myaccount/adminsettings/order/${order.id}`}>
    <div>  OrderId: {order.id}  </div>
    <div>  Status: {order.status}</div>
    <div>  Email: {order.email}</div>
    </Link>
  </div>

